### PR TITLE
fix: rowIndex, colIndex calculations in getFrameMapping()

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -36,8 +36,8 @@ function getFrameMapping(metadata) {
       let planePositions = functionalGroups[j].PlanePositionSlideSequence[0];
       let rowPosition = planePositions.RowPositionInTotalImagePixelMatrix;
       let columnPosition = planePositions.ColumnPositionInTotalImagePixelMatrix;
-      let rowIndex = Math.ceil(rowPosition / columns);
-      let colIndex = Math.ceil(columnPosition / rows);
+      let rowIndex = Math.ceil(rowPosition / rows);
+      let colIndex = Math.ceil(columnPosition / columns);
       let index = rowIndex + '-' + colIndex;
       let frameNumber = j + 1;
       frameMapping[index] = `${sopInstanceUID}/frames/${frameNumber}`;


### PR DESCRIPTION
'rows': TileHeight (tag: (0x0028, 0x0010))
'columns': TileWidth (tag: (0x0028, 0x0011))

'ColumnPositionInTotalImagePixelMatrix' (tag: (0x0048, 0x021E))
'RowPositionInTotalImagePixelMatrix' (tag: (0x0048, 0x021F))

rowIndex, colIndex should be
  rowIndex = Math.ceil(RowPositionInTotalImagePixelMatrix / TileHeight);
  colIndex = Math.ceil(ColumnPositionInTotalImagePixelMatrix / TileWidth);

If this problem doesn't be fixed, it would fail while TileHeigh != TileWidth
