### PR TITLE
feat: 🎸 Add conditional mouse bindings and dragPan

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -35,7 +35,8 @@ import { ROI } from './roi.js';
 import {
     generateUID,
     mapPixelCoord2SlideCoord,
-    mapSlideCoord2PixelCoord
+    mapSlideCoord2PixelCoord,
+    generateOpenLayersCondition
 } from './utils.js';
 import {
   Point,
@@ -927,8 +928,8 @@ class VLWholeSlideMicroscopyImageViewer {
     }
     const allDrawOptions = Object.assign(defaultDrawOptions, customDrawOptions);
 
-    if (options.condition) {
-      allDrawOptions.condition = options.condition;
+    if (options.bindings) {
+      allDrawOptions.condition = generateOpenLayersCondition(options.bindings);
     }
 
     this[_interactions].draw = new Draw(allDrawOptions);
@@ -964,9 +965,14 @@ class VLWholeSlideMicroscopyImageViewer {
   activateSelectInteraction(options={}) {
     this.deactivateSelectInteraction();
     console.info('activate "select" interaction')
-    this[_interactions].select = new Select({
-      layers: [this[_drawingLayer]]
-    });
+
+    const selectOptions = {layers: [this[_drawingLayer]]}
+
+    if (options.bindings) {
+      selectOptions.condition = generateOpenLayersCondition(options.bindings);
+    }
+
+    this[_interactions].select = new Select(selectOptions);
 
     const container = this[_map].getTargetElement();
 
@@ -1002,10 +1008,10 @@ class VLWholeSlideMicroscopyImageViewer {
       features: this[_features],  // TODO: or source, i.e. "drawings"???
     }
 
-    if (options.condition) {
-      modifyOptions.condition = options.condition;
+    if (options.bindings) {
+      modifyOptions.condition = generateOpenLayersCondition(options.bindings);
     }
-
+    
     this[_interactions].modify = new Modify(
       modifyOptions
     );
@@ -1036,8 +1042,8 @@ class VLWholeSlideMicroscopyImageViewer {
       features: this[_features],  // TODO: or source, i.e. "drawings"???
     }
 
-    if (options.condition) {
-      modifyOptions.condition = options.condition;
+    if (options.bindings) {
+      modifyOptions.condition = generateOpenLayersCondition(options.bindings);
     }
 
     this[_interactions].dragPan = new DragPan(

--- a/src/api.js
+++ b/src/api.js
@@ -6,6 +6,7 @@ import Feature from 'ol/Feature';
 import FullScreen from 'ol/control/FullScreen';
 import Map from 'ol/Map';
 import Modify from 'ol/interaction/Modify';
+import DragPan from 'ol/interaction/DragPan';
 import MouseWheelZoom from 'ol/interaction/MouseWheelZoom';
 import OverviewMap from 'ol/control/OverviewMap';
 import Projection from 'ol/proj/Projection';
@@ -729,7 +730,8 @@ class VLWholeSlideMicroscopyImageViewer {
     this[_interactions] = {
       draw: undefined,
       select: undefined,
-      modify: undefined
+      modify: undefined,
+      dragPan: undefined
     };
 
     this[_controls] = {
@@ -924,6 +926,11 @@ class VLWholeSlideMicroscopyImageViewer {
       customDrawOptions.style = options.style;
     }
     const allDrawOptions = Object.assign(defaultDrawOptions, customDrawOptions);
+
+    if (options.condition) {
+      allDrawOptions.condition = options.condition;
+    }
+
     this[_interactions].draw = new Draw(allDrawOptions);
 
     const container = this[_map].getTargetElement();
@@ -989,11 +996,25 @@ class VLWholeSlideMicroscopyImageViewer {
   activateModifyInteraction(options={}) {
     this.deactivateModifyInteraction();
     console.info('activate "modify" interaction')
-    this[_interactions].modify = new Modify({
+
+
+    const modifyOptions = {
       features: this[_features],  // TODO: or source, i.e. "drawings"???
-    });
+    }
+
+    if (options.condition) {
+      modifyOptions.condition = options.condition;
+    }
+
+    this[_interactions].modify = new Modify(
+      modifyOptions
+    );
     this[_map].addInteraction(this[_interactions].modify);
   }
+
+
+
+  
 
   /* Deactivate modify interaction.
    */
@@ -1002,6 +1023,37 @@ class VLWholeSlideMicroscopyImageViewer {
     if (this[_interactions].modify) {
       this[_map].removeInteraction(this[_interactions].modify);
       this[_interactions].modify = undefined;
+    }
+  }
+
+
+  activateDragPanInteraction(options={}) {
+    this.deactivateDragPanInteraction();
+    console.info('activate "drag pan" interaction')
+
+
+    const modifyOptions = {
+      features: this[_features],  // TODO: or source, i.e. "drawings"???
+    }
+
+    if (options.condition) {
+      modifyOptions.condition = options.condition;
+    }
+
+    this[_interactions].dragPan = new DragPan(
+      modifyOptions
+    );
+    this[_map].addInteraction(this[_interactions].dragPan);
+  }
+
+
+  /* Deactivate drag pan interaction.
+   */
+  deactivateDragPanInteraction() {
+    console.info('deactivate "drag pan" interaction')
+    if (this[_interactions].modify) {
+      this[_map].removeInteraction(this[_interactions].dragPan);
+      this[_interactions].dragPan = undefined;
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,33 +1,31 @@
-import { cross, inv, multiply } from 'mathjs'
-
+import { cross, inv, multiply } from "mathjs";
 
 function generateUID() {
-  /*
-   * http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_B.2.html
-   * https://www.itu.int/rec/T-REC-X.667-201210-I/en
-   *  A UUID can be represented as a single integer value.
-   * To obtain the single integer value of the UUID, the 16 octets of the
-   * binary representation shall be treated as an unsigned integer encoding
-   * with the most significant bit of the integer encoding as the most
-   * significant bit (bit 7) of the first of the sixteen octets (octet 15) and
-   * the least significant bit as the least significant bit (bit 0) of the last
-   * of the sixteen octets (octet 0).
-  */
-  // FIXME: This is not a valid UUID!
-  let uid = '2.25.' + Math.floor(1 + Math.random() * 9);
-  while (uid.length < 44) {
-    uid += Math.floor(1 + Math.random() * 10);
-  }
-  return uid;
+    /*
+     * http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_B.2.html
+     * https://www.itu.int/rec/T-REC-X.667-201210-I/en
+     *  A UUID can be represented as a single integer value.
+     * To obtain the single integer value of the UUID, the 16 octets of the
+     * binary representation shall be treated as an unsigned integer encoding
+     * with the most significant bit of the integer encoding as the most
+     * significant bit (bit 7) of the first of the sixteen octets (octet 15) and
+     * the least significant bit as the least significant bit (bit 0) of the last
+     * of the sixteen octets (octet 0).
+     */
+    // FIXME: This is not a valid UUID!
+    let uid = "2.25." + Math.floor(1 + Math.random() * 9);
+    while (uid.length < 44) {
+        uid += Math.floor(1 + Math.random() * 10);
+    }
+    return uid;
 }
-
 
 function mapPixelCoord2SlideCoord(options) {
     // X and Y Offset in Slide Coordinate System
-    if (!('offset' in options) ) {
+    if (!("offset" in options)) {
         throw new Error('Option "offset" is required.');
     }
-    if (!(Array.isArray(options.offset))) {
+    if (!Array.isArray(options.offset)) {
         throw new Error('Option "offset" must be an array.');
     }
     if (options.offset.length !== 2) {
@@ -36,22 +34,24 @@ function mapPixelCoord2SlideCoord(options) {
     const offset = options.offset;
 
     // Image Orientation Slide with direction cosines for Row and Column direction
-    if (!('orientation' in options) ) {
+    if (!("orientation" in options)) {
         throw new Error('Option "orientation" is required.');
     }
-    if (!(Array.isArray(options.orientation))) {
+    if (!Array.isArray(options.orientation)) {
         throw new Error('Option "orientation" must be an array.');
     }
     if (options.orientation.length !== 6) {
-        throw new Error('Option "orientation" must be an array with 6 elements.');
+        throw new Error(
+            'Option "orientation" must be an array with 6 elements.'
+        );
     }
     const orientation = options.orientation;
 
     // Pixel Spacing along the Row and Column direction
-    if (!('spacing' in options) ) {
+    if (!("spacing" in options)) {
         throw new Error('Option "spacing" is required.');
     }
-    if (!(Array.isArray(options.spacing))) {
+    if (!Array.isArray(options.spacing)) {
         throw new Error('Option "spacing" must be an array.');
     }
     if (options.spacing.length !== 2) {
@@ -60,10 +60,10 @@ function mapPixelCoord2SlideCoord(options) {
     const spacing = options.spacing;
 
     // Row and Column position in the Total Pixel Matrix
-    if (!('point' in options) ) {
+    if (!("point" in options)) {
         throw new Error('Option "point" is required.');
     }
-    if (!(Array.isArray(options.point))) {
+    if (!Array.isArray(options.point)) {
         throw new Error('Option "point" must be an array.');
     }
     if (options.point.length !== 2) {
@@ -72,16 +72,12 @@ function mapPixelCoord2SlideCoord(options) {
     const point = options.point;
 
     const m = [
-      [orientation[0] * spacing[1], orientation[3] * spacing[0], offset[0]],
-      [orientation[1] * spacing[1], orientation[4] * spacing[0], offset[1]],
-      [0, 0, 1]
+        [orientation[0] * spacing[1], orientation[3] * spacing[0], offset[0]],
+        [orientation[1] * spacing[1], orientation[4] * spacing[0], offset[1]],
+        [0, 0, 1]
     ];
 
-    const vImage = [
-        [point[0]],
-        [point[1]],
-        [1]
-    ];
+    const vImage = [[point[0]], [point[1]], [1]];
 
     const vSlide = multiply(m, vImage);
 
@@ -90,13 +86,12 @@ function mapPixelCoord2SlideCoord(options) {
     return [x, y];
 }
 
-
 function mapSlideCoord2PixelCoord(options) {
     // X and Y Offset in Slide Coordinate System
-    if (!('offset' in options) ) {
+    if (!("offset" in options)) {
         throw new Error('Option "offset" is required.');
     }
-    if (!(Array.isArray(options.offset))) {
+    if (!Array.isArray(options.offset)) {
         throw new Error('Option "offset" must be an array.');
     }
     if (options.offset.length !== 2) {
@@ -105,22 +100,24 @@ function mapSlideCoord2PixelCoord(options) {
     const offset = options.offset;
 
     // Image Orientation Slide with direction cosines for Row and Column direction
-    if (!('orientation' in options) ) {
+    if (!("orientation" in options)) {
         throw new Error('Option "orientation" is required.');
     }
-    if (!(Array.isArray(options.orientation))) {
+    if (!Array.isArray(options.orientation)) {
         throw new Error('Option "orientation" must be an array.');
     }
     if (options.orientation.length !== 6) {
-        throw new Error('Option "orientation" must be an array with 6 elements.');
+        throw new Error(
+            'Option "orientation" must be an array with 6 elements.'
+        );
     }
     const orientation = options.orientation;
 
     // Pixel Spacing along the Row and Column direction
-    if (!('spacing' in options) ) {
+    if (!("spacing" in options)) {
         throw new Error('Option "spacing" is required.');
     }
-    if (!(Array.isArray(options.spacing))) {
+    if (!Array.isArray(options.spacing)) {
         throw new Error('Option "spacing" must be an array.');
     }
     if (options.spacing.length !== 2) {
@@ -129,10 +126,10 @@ function mapSlideCoord2PixelCoord(options) {
     const spacing = options.spacing;
 
     // X and Y coordinate in the Slide Coordinate System
-    if (!('point' in options) ) {
+    if (!("point" in options)) {
         throw new Error('Option "point" is required.');
     }
-    if (!(Array.isArray(options.point))) {
+    if (!Array.isArray(options.point)) {
         throw new Error('Option "point" must be an array.');
     }
     if (options.point.length !== 2) {
@@ -141,17 +138,13 @@ function mapSlideCoord2PixelCoord(options) {
     const point = options.point;
 
     const m = [
-      [orientation[0] * spacing[1], orientation[3] * spacing[0], offset[0]],
-      [orientation[1] * spacing[1], orientation[4] * spacing[0], offset[1]],
-      [0, 0, 1]
+        [orientation[0] * spacing[1], orientation[3] * spacing[0], offset[0]],
+        [orientation[1] * spacing[1], orientation[4] * spacing[0], offset[1]],
+        [0, 0, 1]
     ];
     const mInverted = inv(m);
 
-    const vSlide = [
-        [point[0]],
-        [point[1]],
-        [1]
-    ];
+    const vSlide = [[point[0]], [point[1]], [1]];
 
     const vImage = multiply(mInverted, vSlide);
 
@@ -160,4 +153,68 @@ function mapSlideCoord2PixelCoord(options) {
     return [col, row];
 }
 
-export { generateUID, mapPixelCoord2SlideCoord, mapSlideCoord2PixelCoord };
+function generateOpenLayersCondition(bindings) {
+    const { mouseButtons, modifierKey } = bindings;
+
+    const mouseButtonCondition = e => {
+        if (!mouseButtons || !mouseButtons.length) {
+            // No mouse button condition set.
+            return true;
+        }
+
+        const button = e.pointerEvent.buttons;
+
+        return mouseButtons.some(mb => BUTTONS[mb] === button);
+    };
+
+    const modifierKeyCondition = e => {
+        const { pointerEvent } = e;
+
+        if (!modifierKey) {
+            // No modifier key, don't pass if key pressed as other tool may be using this tool.
+            return (
+                !pointerEvent.altKey &&
+                !pointerEvent.metaKey &&
+                !pointerEvent.shiftKey &&
+                !pointerEvent.ctrlKey
+            );
+        }
+
+        switch (modifierKey) {
+            case "alt":
+                return (
+                    pointerEvent.altKey === true ||
+                    pointerEvent.metaKey === true
+                );
+            case "shift":
+                return pointerEvent.shiftKey === true;
+            case "ctrl":
+                return pointerEvent.ctrlKey === true;
+            default:
+                // invalid modifier key set (ignore requirement as if key not pressed).
+                return (
+                    !pointerEvent.altKey &&
+                    !pointerEvent.metaKey &&
+                    !pointerEvent.shiftKey &&
+                    !pointerEvent.ctrlKey
+                );
+        }
+    };
+
+    return function(e) {
+        return mouseButtonCondition(e) && modifierKeyCondition(e);
+    };
+}
+
+const BUTTONS = {
+    left: 1,
+    middle: 4,
+    right: 2
+};
+
+export {
+    generateUID,
+    mapPixelCoord2SlideCoord,
+    mapSlideCoord2PixelCoord,
+    generateOpenLayersCondition
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
-import { cross, inv, multiply } from "mathjs";
+import { cross, inv, multiply } from 'mathjs'
+
 
 function generateUID() {
     /*
@@ -11,21 +12,22 @@ function generateUID() {
      * significant bit (bit 7) of the first of the sixteen octets (octet 15) and
      * the least significant bit as the least significant bit (bit 0) of the last
      * of the sixteen octets (octet 0).
-     */
+    */
     // FIXME: This is not a valid UUID!
-    let uid = "2.25." + Math.floor(1 + Math.random() * 9);
+    let uid = '2.25.' + Math.floor(1 + Math.random() * 9);
     while (uid.length < 44) {
         uid += Math.floor(1 + Math.random() * 10);
     }
     return uid;
 }
 
+
 function mapPixelCoord2SlideCoord(options) {
     // X and Y Offset in Slide Coordinate System
-    if (!("offset" in options)) {
+    if (!('offset' in options)) {
         throw new Error('Option "offset" is required.');
     }
-    if (!Array.isArray(options.offset)) {
+    if (!(Array.isArray(options.offset))) {
         throw new Error('Option "offset" must be an array.');
     }
     if (options.offset.length !== 2) {
@@ -34,24 +36,22 @@ function mapPixelCoord2SlideCoord(options) {
     const offset = options.offset;
 
     // Image Orientation Slide with direction cosines for Row and Column direction
-    if (!("orientation" in options)) {
+    if (!('orientation' in options)) {
         throw new Error('Option "orientation" is required.');
     }
-    if (!Array.isArray(options.orientation)) {
+    if (!(Array.isArray(options.orientation))) {
         throw new Error('Option "orientation" must be an array.');
     }
     if (options.orientation.length !== 6) {
-        throw new Error(
-            'Option "orientation" must be an array with 6 elements.'
-        );
+        throw new Error('Option "orientation" must be an array with 6 elements.');
     }
     const orientation = options.orientation;
 
     // Pixel Spacing along the Row and Column direction
-    if (!("spacing" in options)) {
+    if (!('spacing' in options)) {
         throw new Error('Option "spacing" is required.');
     }
-    if (!Array.isArray(options.spacing)) {
+    if (!(Array.isArray(options.spacing))) {
         throw new Error('Option "spacing" must be an array.');
     }
     if (options.spacing.length !== 2) {
@@ -60,10 +60,10 @@ function mapPixelCoord2SlideCoord(options) {
     const spacing = options.spacing;
 
     // Row and Column position in the Total Pixel Matrix
-    if (!("point" in options)) {
+    if (!('point' in options)) {
         throw new Error('Option "point" is required.');
     }
-    if (!Array.isArray(options.point)) {
+    if (!(Array.isArray(options.point))) {
         throw new Error('Option "point" must be an array.');
     }
     if (options.point.length !== 2) {
@@ -77,7 +77,11 @@ function mapPixelCoord2SlideCoord(options) {
         [0, 0, 1]
     ];
 
-    const vImage = [[point[0]], [point[1]], [1]];
+    const vImage = [
+        [point[0]],
+        [point[1]],
+        [1]
+    ];
 
     const vSlide = multiply(m, vImage);
 
@@ -86,12 +90,13 @@ function mapPixelCoord2SlideCoord(options) {
     return [x, y];
 }
 
+
 function mapSlideCoord2PixelCoord(options) {
     // X and Y Offset in Slide Coordinate System
-    if (!("offset" in options)) {
+    if (!('offset' in options)) {
         throw new Error('Option "offset" is required.');
     }
-    if (!Array.isArray(options.offset)) {
+    if (!(Array.isArray(options.offset))) {
         throw new Error('Option "offset" must be an array.');
     }
     if (options.offset.length !== 2) {
@@ -100,24 +105,22 @@ function mapSlideCoord2PixelCoord(options) {
     const offset = options.offset;
 
     // Image Orientation Slide with direction cosines for Row and Column direction
-    if (!("orientation" in options)) {
+    if (!('orientation' in options)) {
         throw new Error('Option "orientation" is required.');
     }
-    if (!Array.isArray(options.orientation)) {
+    if (!(Array.isArray(options.orientation))) {
         throw new Error('Option "orientation" must be an array.');
     }
     if (options.orientation.length !== 6) {
-        throw new Error(
-            'Option "orientation" must be an array with 6 elements.'
-        );
+        throw new Error('Option "orientation" must be an array with 6 elements.');
     }
     const orientation = options.orientation;
 
     // Pixel Spacing along the Row and Column direction
-    if (!("spacing" in options)) {
+    if (!('spacing' in options)) {
         throw new Error('Option "spacing" is required.');
     }
-    if (!Array.isArray(options.spacing)) {
+    if (!(Array.isArray(options.spacing))) {
         throw new Error('Option "spacing" must be an array.');
     }
     if (options.spacing.length !== 2) {
@@ -126,10 +129,10 @@ function mapSlideCoord2PixelCoord(options) {
     const spacing = options.spacing;
 
     // X and Y coordinate in the Slide Coordinate System
-    if (!("point" in options)) {
+    if (!('point' in options)) {
         throw new Error('Option "point" is required.');
     }
-    if (!Array.isArray(options.point)) {
+    if (!(Array.isArray(options.point))) {
         throw new Error('Option "point" must be an array.');
     }
     if (options.point.length !== 2) {
@@ -144,7 +147,11 @@ function mapSlideCoord2PixelCoord(options) {
     ];
     const mInverted = inv(m);
 
-    const vSlide = [[point[0]], [point[1]], [1]];
+    const vSlide = [
+        [point[0]],
+        [point[1]],
+        [1]
+    ];
 
     const vImage = multiply(mInverted, vSlide);
 
@@ -153,68 +160,4 @@ function mapSlideCoord2PixelCoord(options) {
     return [col, row];
 }
 
-function generateOpenLayersCondition(bindings) {
-    const { mouseButtons, modifierKey } = bindings;
-
-    const mouseButtonCondition = e => {
-        if (!mouseButtons || !mouseButtons.length) {
-            // No mouse button condition set.
-            return true;
-        }
-
-        const button = e.pointerEvent.buttons;
-
-        return mouseButtons.some(mb => BUTTONS[mb] === button);
-    };
-
-    const modifierKeyCondition = e => {
-        const { pointerEvent } = e;
-
-        if (!modifierKey) {
-            // No modifier key, don't pass if key pressed as other tool may be using this tool.
-            return (
-                !pointerEvent.altKey &&
-                !pointerEvent.metaKey &&
-                !pointerEvent.shiftKey &&
-                !pointerEvent.ctrlKey
-            );
-        }
-
-        switch (modifierKey) {
-            case "alt":
-                return (
-                    pointerEvent.altKey === true ||
-                    pointerEvent.metaKey === true
-                );
-            case "shift":
-                return pointerEvent.shiftKey === true;
-            case "ctrl":
-                return pointerEvent.ctrlKey === true;
-            default:
-                // invalid modifier key set (ignore requirement as if key not pressed).
-                return (
-                    !pointerEvent.altKey &&
-                    !pointerEvent.metaKey &&
-                    !pointerEvent.shiftKey &&
-                    !pointerEvent.ctrlKey
-                );
-        }
-    };
-
-    return function(e) {
-        return mouseButtonCondition(e) && modifierKeyCondition(e);
-    };
-}
-
-const BUTTONS = {
-    left: 1,
-    middle: 4,
-    right: 2
-};
-
-export {
-    generateUID,
-    mapPixelCoord2SlideCoord,
-    mapSlideCoord2PixelCoord,
-    generateOpenLayersCondition
-};
+export { generateUID, mapPixelCoord2SlideCoord, mapSlideCoord2PixelCoord };


### PR DESCRIPTION
This PR adds conditionals so that you can bind tools to different mouse buttons, it also exposes the `ol/interaction/DragPan` open layers interaction.

I'm using this in order to have tool on left click and pan on middle, to get similar controls in the microscopy viewport to the cornerstone viewports in OHIF.

I also wanted right click to zoom, which would zoom on the focus, but I tried these following two tools to no success:
- `ol/interaction/DragZoom` - This doesn't do what I would have expected, and draws a rectangle and zooms to it.
- `ol/interaction/DragRotateAndZoom` - This one is almost there other than having built in rotate. If I disabled rotation on the `ol/View` the interaction just feels broken, as you can only zoom when the mouse is near the centre of the viewport. It also only zooms on the centre rather than

If anyone knows a way to get the `MouseWheelZoom` interaction bound to mouseDrag up/down I'd love to hear solutions!