### PR TITLE
Add support for dynamically configuring the dicomicc iccOutputType

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "dicomweb-client": "^0.10.3",
     "colormap": "^2.3",
     "dcmjs": "^0.38.1",
-    "dicomicc": "^0.1",
+    "dicomicc": "^0.2",
     "image-type": "^4.1",
     "mathjs": "^11.2",
     "ol": "^10.4.0",

--- a/src/decode.js
+++ b/src/decode.js
@@ -10,7 +10,8 @@ function _processDecodeAndTransformTask (
   samplesPerPixel,
   sopInstanceUID,
   metadata,
-  iccProfiles
+  iccProfiles,
+  iccOutputType = "srgb" // "srgb" or "display-p3"
 ) {
   const priority = undefined
   const transferList = undefined
@@ -26,7 +27,8 @@ function _processDecodeAndTransformTask (
       samplesPerPixel,
       sopInstanceUID,
       metadata,
-      iccProfiles
+      iccProfiles,
+      iccOutputType
     },
     priority,
     transferList
@@ -42,7 +44,8 @@ async function _decodeAndTransformFrame ({
   samplesPerPixel,
   sopInstanceUID,
   metadata, // metadata of all images (different resolution levels)
-  iccProfiles // ICC profiles for all images
+  iccProfiles, // ICC profiles for all images
+  iccOutputType = "srgb" // "srgb" or "display-p3"
 }) {
   const result = await _processDecodeAndTransformTask(
     frame,
@@ -53,7 +56,8 @@ async function _decodeAndTransformFrame ({
     samplesPerPixel,
     sopInstanceUID,
     metadata,
-    iccProfiles
+    iccProfiles,
+    iccOutputType
   )
 
   const signed = pixelRepresentation === 1

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -362,6 +362,7 @@ function _createTileLoadFunction ({
   client,
   channel,
   iccProfiles,
+  iccOutputType,
   targetElement
 }) {
   return async (z, y, x) => {
@@ -507,7 +508,8 @@ function _createTileLoadFunction ({
             samplesPerPixel,
             sopInstanceUID,
             metadata: pyramid.metadata,
-            iccProfiles
+            iccProfiles,
+            iccOutputType
           }).then(pixelArray => {
             if (pixelArray.constructor === Float64Array) {
               // TODO: handle Float64Array using LUT

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1128,6 +1128,8 @@ class VolumeImageViewer {
 
     /**
      * Detect the display color space.
+     * Note: The WebGLRenderingContext only supports sRGB and Display-P3
+     * color spaces, Adobe RGB (1998) and ROMM RGB are not supported.
      * @returns {string} 'display-p3' or 'srgb'
      */
     function detectDisplayColorSpace() {
@@ -2327,6 +2329,7 @@ class VolumeImageViewer {
         const loader = _createTileLoadFunction({
           targetElement: container,
           iccProfiles: profiles,
+          iccOutputType: this[_iccOutputType],
           ...opticalPath.loaderParams
         })
         const source = opticalPath.layer.getSource()
@@ -2497,6 +2500,7 @@ class VolumeImageViewer {
       const loader = _createTileLoadFunction({
         targetElement: container,
         iccProfiles: this[_isICCProfilesEnabled] && profiles.length > 0 ? profiles : null,
+        iccOutputType: this[_isICCProfilesEnabled] && profiles.length > 0 ? this[_iccOutputType] : null,
         ...item.loaderParams
       })
       source.setLoader(loader)

--- a/src/webWorker/decodeAndTransformTask.js
+++ b/src/webWorker/decodeAndTransformTask.js
@@ -27,7 +27,8 @@ function _handler (data, doneCallback) {
     frame,
     sopInstanceUID,
     metadata,
-    iccProfiles
+    iccProfiles,
+    iccOutputType = "srgb" // "srgb" or "display-p3"
   } = data.data
 
   _checkImageTypeAndDecode(
@@ -43,7 +44,7 @@ function _handler (data, doneCallback) {
     if (iccProfiles != null && iccProfiles.length > 0) {
       // Only instantiate the transformer once and cache it for reuse.
       if (transformerColor === undefined) {
-        transformerColor = new ColorTransformer(metadata, iccProfiles)
+        transformerColor = new ColorTransformer(metadata, iccProfiles, iccOutputType)
       }
       // Apply ICC color transform
       transformerColor.transform(

--- a/src/webWorker/transformers/transformerICC.js
+++ b/src/webWorker/transformers/transformerICC.js
@@ -9,8 +9,9 @@ export default class ColorTransformer extends Transformer {
    * @param {Array<metadata.VLWholeSlideMicroscopyImage>} - Metadata of each
    * image
    * @param {Array<TypedArray>} - ICC profiles of each image
+   * @param {number} [iccOutputType="srgb"] - ICC output type ("srgb": sRGB (default) or "display-p3": Display-P3).
    */
-  constructor (metadata, iccProfiles) {
+  constructor (metadata, iccProfiles, iccOutputType = "srgb") {
     super()
     if (metadata.length !== iccProfiles.length) {
       throw new Error(
@@ -22,6 +23,8 @@ export default class ColorTransformer extends Transformer {
     this.iccProfiles = iccProfiles
     this.codec = null
     this.transformers = {}
+    // ColorManager ICC output type: 0: sRGB, 1: Display-P3
+    this.iccOutputType = iccOutputType === "display-p3" ? 1 : 0;
   }
 
   _initialize () {
@@ -58,7 +61,8 @@ export default class ColorTransformer extends Transformer {
               samplesPerPixel,
               planarConfiguration
             },
-            profile
+            profile,
+            this.iccOutputType
           )
         }
         resolve(this.transformers)


### PR DESCRIPTION
The original implementation assumes the display used to view the WSI images is using the sRGB color space.
Now we first check if the display color space is sRGB or Display-P3 (a more recent wide-gamut color space).
Based on this dicomicc is configured to either transform colors to the sRGB color space or to the Display-P3 color space. Prerequisite: approval of Pull Request to add support for Display-P3 in libdicomicc (https://github.com/ImagingDataCommons/libdicomicc/pull/6)