### PR TITLE
Add hide/show for single ROI

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1304,7 +1304,9 @@ class VolumeImageViewer {
           )
           const error = new CustomError(
             errorTypes.VISUALIZATION,
-            `error loading tile of optical path "${opticalPathIdentifier}": ${event.tile?.error_?.message || event.message}`,
+            `error loading tile of optical path "${opticalPathIdentifier}": ${
+              event.tile?.error_?.message || event.message
+            }`,
           )
           this[_options].errorInterceptor(error)
         })
@@ -1424,7 +1426,9 @@ class VolumeImageViewer {
         )
         const error = new CustomError(
           errorTypes.VISUALIZATION,
-          `error loading tile of optical path "${opticalPathIdentifier}": ${event.tile?.error_?.message || event.message}`,
+          `error loading tile of optical path "${opticalPathIdentifier}": ${
+            event.tile?.error_?.message || event.message
+          }`,
         )
         this[_options].errorInterceptor(error)
       })
@@ -3773,6 +3777,39 @@ class VolumeImageViewer {
    */
   get areROIsVisible() {
     return this[_drawingLayer].getVisible()
+  }
+
+  /**
+   * Hide an individual region of interest.
+   *
+   * @param {string} uid - Unique identifier of the region of interest
+   */
+  hideROI(uid) {
+    console.info(`hide ROI ${uid}`)
+    const feature = this[_drawingSource].getFeatureById(uid)
+    if (!feature) return
+
+    feature.setStyle(_getOpenLayersStyle({}))
+
+    this[_annotationManager].setMarkupVisibility(uid, false)
+  }
+
+  /**
+   * Show an individual region of interest.
+   *
+   * @param {string} uid - Unique identifier of the region of interest
+   */
+  showROI(uid) {
+    console.info(`show ROI ${uid}`)
+    const feature = this[_drawingSource].getFeatureById(uid)
+    if (!feature) return
+
+    const styleOptions =
+      feature.get(Enums.InternalProperties.StyleOptions) || {}
+
+    _setFeatureStyle(feature, styleOptions)
+
+    this[_annotationManager].setMarkupVisibility(uid, true)
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR adds public viewer APIs to hide/show a single ROI by UID.

## Motivation
This addresses a gap in the library API where consuming applications (like OHIF Viewer) need to toggle visibility of individual measurements/annotations via UI controls (e.g., eye icons in measurement panels). Without single-ROI visibility control, users could only hide/show all annotations at once. 

## Changes Made
New Public Methods in VolumeImageViewer:

**hideROI(uid)** - Hides an individual region of interest by its unique identifier
- Sets feature geometry to invisible style while preserving original styleOptions
- Hides associated markup overlays 

**showROI(uid)** - Shows a previously hidden region of interest
- Restores the feature geometry using stored styleOptions
- Shows associated markup overlays

## Test plan
- Add a ROI, confirm it renders with its markup (if applicable).
- Call hideROI(uid): ROI geometry disappears and its markup/link disappear.
- Call showROI(uid): ROI geometry and markup/link return.