### PR TITLE
feat: export bulk annotation and graphic-fetch APIs for Viv / non-OpenLayers consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dicom-microscopy-viewer",
-  "version": "0.48.20",
+  "version": "0.48.21",
   "license": "MIT",
   "author": "ImagingDataCommons",
   "homepage": "https://github.com/imagingdatacommons/dicom-microscopy-viewer#readme",

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -915,4 +915,9 @@ export {
   _getCoordinateDimensionality,
   _getPoint,
   _getCoordinates,
+  /** Stable public alias for non–OpenLayers consumers (e.g. Slim Viv / Deck.gl). */
+  _fetchGraphicData as fetchGraphicData,
+  _fetchGraphicIndex as fetchGraphicIndex,
+  _getCommonZCoordinate as getCommonZCoordinate,
+  _getCoordinateDimensionality as getCoordinateDimensionality,
 }

--- a/src/dicom-microscopy-viewer.js
+++ b/src/dicom-microscopy-viewer.js
@@ -1,4 +1,20 @@
-import { AnnotationGroup } from './annotation.js'
+import {
+  AnnotationGroup,
+  fetchGraphicData,
+  fetchGraphicIndex,
+  getCommonZCoordinate,
+  getCoordinateDimensionality,
+} from './annotation.js'
+import {
+  getCircleFeature,
+  getEllipseFeature,
+  getFeaturesFromBulkAnnotations,
+  getPointFeature,
+  getPolygonFeature,
+  getRectangleFeature,
+  getViewportBoundingBox,
+  isCoordinateInsideBoundingBox,
+} from './bulkAnnotations/utils.js'
 import {
   buildPaletteColorLookupTable,
   ColormapNames,
@@ -45,12 +61,34 @@ import {
 
 /**
  * Namespace for annotations of DICOM Micrsocopy Bulk Simple Annotations
- * instances.
+ * instances. Exposes fetch/coordinate helpers for Deck.gl without using
+ * {@link viewer.VolumeImageViewer#addAnnotationGroups}.
  *
  * @namespace annotation
  */
 const annotation = {
   AnnotationGroup,
+  fetchGraphicData,
+  fetchGraphicIndex,
+  getCommonZCoordinate,
+  getCoordinateDimensionality,
+}
+
+/**
+ * Bulk Simple Annotation geometry (OpenLayers features). Same code as
+ * {@link viewer.VolumeImageViewer#addAnnotationGroups}.
+ *
+ * @namespace bulkSimpleAnnotations
+ */
+const bulkSimpleAnnotations = {
+  getFeaturesFromBulkAnnotations,
+  getPointFeature,
+  getPolygonFeature,
+  getCircleFeature,
+  getEllipseFeature,
+  getRectangleFeature,
+  getViewportBoundingBox,
+  isCoordinateInsideBoundingBox,
 }
 
 /**
@@ -179,6 +217,7 @@ const utils = {
 export {
   annotation,
   api,
+  bulkSimpleAnnotations,
   color,
   events,
   mapping,


### PR DESCRIPTION
## Summary

Small **public API extension** so SLIM’s optional **Viv / Deck.gl** viewer can reuse the **same Microscopy Bulk Simple Annotation decode path** as the existing OpenLayers `VolumeImageViewer` flow—without copying logic or poking private internals.

**Branch:** `feat/viv-loader`  
**Pairs with:** SLIM PR on `feat/viv-loader` (links against this DMV branch or a release that includes these exports).

## What changed

- **`annotation` namespace** now also exposes stable helpers previously only used inside the viewer:
  - `fetchGraphicData`, `fetchGraphicIndex`
  - `getCommonZCoordinate`, `getCoordinateDimensionality`  
  (Implemented as public aliases of the existing `_fetchGraphicData`, `_fetchGraphicIndex`, etc., in `annotation.js`.)

- **New `bulkSimpleAnnotations` namespace** on the main export bundle, re-exporting the existing helpers from `bulkAnnotations/utils.js` (e.g. `getFeaturesFromBulkAnnotations`, `getPolygonFeature`, bbox helpers, shape constructors). Same building blocks `addAnnotationGroups` already uses.

- **Version** bumped in `package.json` (patch) for a releasable cut once reviewed.

## Why

Viv needs to **fetch graphic frames / indices** and **turn bulk annotation instances into geometry** the same way OpenLayers does. Exporting these under clear names keeps **one implementation** in DMV and avoids Slim forking decode code.

## How to verify

1. **Regression:** Existing slides with bulk annotations still load and behave in the **classic OpenLayers** viewer (no change intended to `addAnnotationGroups` behavior).

2. **Integration:** From a consumer (e.g. linked SLIM `feat/viv-loader`), `import * as dmv from 'dicom-microscopy-viewer'` and confirm `dmv.annotation.*` and `dmv.bulkSimpleAnnotations.*` are defined and produce the same results as the internal path for a known fixture.

## Notes

- This is intentionally **additive**: new exports and namespaces only; core OpenLayers pipeline should be unchanged.

- After merge, publish **0.48.21** (or align version with release policy) and point SLIM at the **npm tarball** instead of `bun link` / `file:` when ready.