### PR TITLE
fix: interpret Palette Color LUT data by descriptor bits per entry

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -5,6 +5,79 @@ import { _generateUID, rescale } from './utils.js'
 const _attrs = Symbol('attrs')
 
 /**
+ * Normalize Palette Color Lookup Table Data to a typed array whose element
+ * size matches the number of bits per entry declared in the LUT descriptor.
+ *
+ * The Palette Color Lookup Table Data attributes have VR OW, so 8-bit LUT
+ * entries are byte-packed inside 16-bit words. Depending on how the dataset is
+ * retrieved and parsed, the data may reach us as a raw ArrayBuffer (e.g. from
+ * `dcmjs.data.DicomMessage.readFile`), as a typed array whose element size
+ * reflects the VR rather than the descriptor (e.g. a Uint16Array produced for
+ * an OW element that actually holds 8-bit entries), or as a plain array of
+ * per-entry numbers (e.g. from a US element in DICOM JSON). The descriptor's
+ * third value is authoritative for the element size, so reinterpret the
+ * underlying bytes accordingly instead of trusting the source element size.
+ *
+ * @param {ArrayBuffer|Uint8Array|Uint16Array|number[]} data - LUT data
+ * @param {Uint8ArrayConstructor|Uint16ArrayConstructor} DataType - Typed array
+ * constructor implied by the bits per entry (Uint8Array for 8, Uint16Array for
+ * 16)
+ *
+ * @returns {Uint8Array|Uint16Array|undefined} LUT data with the correct
+ * element size
+ *
+ * @private
+ */
+function _normalizeLUTData(data, DataType) {
+  if (data == null) {
+    return undefined
+  }
+  if (data instanceof ArrayBuffer) {
+    return new DataType(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    // Reinterpret the underlying bytes so that the element size matches the
+    // descriptor rather than the source typed array's element size.
+    return new DataType(
+      data.buffer,
+      data.byteOffset,
+      data.byteLength / DataType.BYTES_PER_ELEMENT,
+    )
+  }
+  // Plain array of per-entry numbers: copy element-wise.
+  return new DataType(data)
+}
+
+/**
+ * Normalize Segmented Palette Color Lookup Table Data to a Uint16Array.
+ *
+ * Segmented LUT Data has VR OW and is composed of 16-bit segment opcodes and
+ * values, so it must always be interpreted as 16-bit words regardless of how
+ * it was delivered.
+ *
+ * @param {ArrayBuffer|Uint8Array|Uint16Array|number[]} data - Segmented LUT data
+ *
+ * @returns {Uint16Array|undefined} Segmented LUT data as 16-bit words
+ *
+ * @private
+ */
+function _normalizeSegmentedLUTData(data) {
+  if (data == null) {
+    return undefined
+  }
+  if (data instanceof Uint16Array) {
+    return data
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint16Array(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new Uint16Array(data.buffer, data.byteOffset, data.byteLength / 2)
+  }
+  return Uint16Array.from(data)
+}
+
+/**
  * Enumerated values for color map names.
  *
  * @memberof color
@@ -198,6 +271,22 @@ class PaletteColorLookupTable {
       )
     }
 
+    if (this[_attrs].bitsPerEntry === 8) {
+      this[_attrs].DataType = Uint8Array
+    } else {
+      this[_attrs].DataType = Uint16Array
+    }
+
+    // Interpret the LUT data using the element size implied by the descriptor
+    // (bits per entry) rather than the source representation, which may differ
+    // (e.g. 8-bit entries byte-packed inside an OW/Uint16Array).
+    redData = _normalizeLUTData(redData, this[_attrs].DataType)
+    greenData = _normalizeLUTData(greenData, this[_attrs].DataType)
+    blueData = _normalizeLUTData(blueData, this[_attrs].DataType)
+    redSegmentedData = _normalizeSegmentedLUTData(redSegmentedData)
+    greenSegmentedData = _normalizeSegmentedLUTData(greenSegmentedData)
+    blueSegmentedData = _normalizeSegmentedLUTData(blueSegmentedData)
+
     if (redSegmentedData != null && redData != null) {
       throw new Error(
         'Either Segmented Red Palette Color Lookup Data or Red Palette ' +
@@ -260,12 +349,6 @@ class PaletteColorLookupTable {
     }
     this[_attrs].blueSegmentedData = blueSegmentedData
     this[_attrs].blueData = blueData
-
-    if (this[_attrs].bitsPerEntry === 8) {
-      this[_attrs].DataType = Uint8Array
-    } else {
-      this[_attrs].DataType = Uint16Array
-    }
 
     // Will be used to cache created colormap for repeated access
     this[_attrs].data = null

--- a/src/color.test.js
+++ b/src/color.test.js
@@ -1,0 +1,108 @@
+const { PaletteColorLookupTable } = require('./color')
+
+describe('color.PaletteColorLookupTable', () => {
+  it('interprets non-segmented 8-bit LUT data (descriptor [n, first, 8])', () => {
+    // 256 entries of 8-bit values forming a ramp 0..255.
+    const descriptor = [256, 0, 8]
+    const ramp = new Uint8Array(256)
+    for (let i = 0; i < 256; i++) {
+      ramp[i] = i
+    }
+    const lut = new PaletteColorLookupTable({
+      uid: '1.2.3',
+      redDescriptor: descriptor,
+      greenDescriptor: descriptor,
+      blueDescriptor: descriptor,
+      redData: ramp,
+      greenData: ramp.slice(),
+      blueData: ramp.slice()
+    })
+    expect(lut.data.length).toBe(256)
+    expect(lut.data[0]).toEqual([0, 0, 0])
+    expect(lut.data[255]).toEqual([255, 255, 255])
+  })
+
+  it('interprets 8-bit LUT data byte-packed in an OW ArrayBuffer', () => {
+    // Conformant Presentation States encode 8-bit entries inside an OW element,
+    // which arrives as a raw ArrayBuffer (e.g. via dcmjs readFile). A 256-entry
+    // 8-bit LUT therefore occupies 256 bytes and must NOT be read as 128 16-bit
+    // words.
+    const descriptor = [256, 0, 8]
+    const bytes = new Uint8Array(256)
+    for (let i = 0; i < 256; i++) {
+      bytes[i] = i
+    }
+    const buffer = bytes.buffer
+    const lut = new PaletteColorLookupTable({
+      uid: '1.2.3',
+      redDescriptor: descriptor,
+      greenDescriptor: descriptor,
+      blueDescriptor: descriptor,
+      redData: buffer,
+      greenData: bytes.slice().buffer,
+      blueData: bytes.slice().buffer
+    })
+    expect(lut.data.length).toBe(256)
+    expect(lut.data[0]).toEqual([0, 0, 0])
+    expect(lut.data[255]).toEqual([255, 255, 255])
+  })
+
+  it('reinterprets a Uint16Array that actually holds byte-packed 8-bit entries', () => {
+    // Reproduces the failure mode where a 256-byte OW LUT was eagerly wrapped
+    // in a Uint16Array (yielding 128 elements) before reaching the LUT.
+    const descriptor = [256, 0, 8]
+    const bytes = new Uint8Array(256)
+    for (let i = 0; i < 256; i++) {
+      bytes[i] = i
+    }
+    const packed = new Uint16Array(bytes.buffer) // length 128
+    expect(packed.length).toBe(128)
+    const lut = new PaletteColorLookupTable({
+      uid: '1.2.3',
+      redDescriptor: descriptor,
+      greenDescriptor: descriptor,
+      blueDescriptor: descriptor,
+      redData: packed,
+      greenData: new Uint16Array(bytes.slice().buffer),
+      blueData: new Uint16Array(bytes.slice().buffer)
+    })
+    expect(lut.data.length).toBe(256)
+    expect(lut.data[255]).toEqual([255, 255, 255])
+  })
+
+  it('interprets non-segmented 16-bit LUT data from an ArrayBuffer', () => {
+    const descriptor = [256, 0, 16]
+    const values = new Uint16Array(256)
+    for (let i = 0; i < 256; i++) {
+      values[i] = Math.round((i / 255) * 65535)
+    }
+    const lut = new PaletteColorLookupTable({
+      uid: '1.2.3',
+      redDescriptor: descriptor,
+      greenDescriptor: descriptor,
+      blueDescriptor: descriptor,
+      redData: values.buffer,
+      greenData: values.slice().buffer,
+      blueData: values.slice().buffer
+    })
+    expect(lut.data.length).toBe(256)
+    // 16-bit values are rescaled to 8-bit output.
+    expect(lut.data[255]).toEqual([255, 255, 255])
+  })
+
+  it('throws when the data length does not match the descriptor', () => {
+    const descriptor = [256, 0, 8]
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new PaletteColorLookupTable({
+        uid: '1.2.3',
+        redDescriptor: descriptor,
+        greenDescriptor: descriptor,
+        blueDescriptor: descriptor,
+        redData: new Uint8Array(10),
+        greenData: new Uint8Array(10),
+        blueData: new Uint8Array(10)
+      })
+    }).toThrow(/wrong number of entries/)
+  })
+})


### PR DESCRIPTION
## Summary

`PaletteColorLookupTable` rejected conformant 8-bit, non-segmented Palette Color LUTs, breaking Advanced Blending Presentation States created with `highdicom` (see ImagingDataCommons/slim#390).

Palette Color Lookup Table Data has VR **OW**, so a conformant 8-bit LUT (descriptor `[n, first, 8]`) packs `n` entries into `n` bytes inside the 16-bit-word element. Depending on the retrieval/parse path the data reaches the class as:

- a raw `ArrayBuffer` (e.g. `dcmjs.data.DicomMessage.readFile`),
- a typed array whose element size reflects the VR, not the descriptor (e.g. a `Uint16Array` holding byte-packed 8-bit entries), or
- a plain array of per-entry numbers (e.g. a `US` element in DICOM JSON).

The constructor trusted the source element size and validated `length` against the descriptor, so a 256-entry 8-bit LUT delivered as a 256-byte buffer was seen as 128 entries and threw `Red Palette Color Lookup Table Data has wrong number of entries`.

## What changed

- `src/color.js`
  - Added `_normalizeLUTData()` and `_normalizeSegmentedLUTData()` that reinterpret the underlying bytes to the element size implied by the descriptor's **bits per entry** (`Uint8Array` for 8, `Uint16Array` for 16), handling `ArrayBuffer`, typed arrays of any element size, and plain number arrays.
  - `PaletteColorLookupTable` normalizes Red/Green/Blue (and segmented) data **before** the length check.
- `src/color.test.js` — new regression tests.

This also fixes 8-bit optical-path Palette Color LUTs, and keeps existing 16-bit and segmented LUTs working (backward compatible).

## Test plan

- [x] `npx jest` — 163 passing (5 new in `color.test.js`).
- [x] `biome check .` — clean.
- [x] Verified end-to-end against a real `highdicom` 5-channel Advanced Blending PR (descriptor `[256, 0, 8]`, 256-byte `OW`): all channels now build and produce the expected pseudo-colors instead of throwing.
- [ ] Open a monochrome slide with an Advanced Blending PR that uses conformant non-segmented 8-bit LUTs and confirm channels render.

## Related

- ImagingDataCommons/slim#390 (paired slim PR passes the LUT bytes through unmodified)