### PR TITLE
fix: pin form-data to 3.0.5 to address CRLF injection (Dependabot #89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "pnpm": {
     "overrides": {
       "braces": "3.0.3",
+      "form-data": "3.0.5",
       "minimatch": "3.1.5",
       "serialize-javascript": "7.0.5"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   braces: 3.0.3
+  form-data: 3.0.5
   minimatch: 3.1.5
   serialize-javascript: 7.0.5
 
@@ -1940,8 +1941,8 @@ packages:
       debug:
         optional: true
 
-  form-data@3.0.4:
-    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+  form-data@3.0.5:
+    resolution: {integrity: sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -5923,7 +5924,7 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  form-data@3.0.4:
+  form-data@3.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -6676,7 +6677,7 @@ snapshots:
       decimal.js: 10.6.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.4
+      form-data: 3.0.5
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1


### PR DESCRIPTION
## Summary
- Pin transitive `form-data` to `3.0.5` via pnpm override to fix CRLF injection in multipart field names/filenames (Dependabot alert #89).
- Jest 27 pulls in vulnerable `form-data@3.0.4` through `jsdom`; Dependabot cannot resolve this without an override.

## Test plan
- [x] `pnpm install`
- [x] `pnpm test` (163 tests passed)
- [ ] Confirm Dependabot alert #89 is resolved after merge