### PR TITLE
fix(ci): restore npm publish auth after pnpm migration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: dmv/publish-to-npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   build:
     name: Build and publish to npm
@@ -20,11 +21,19 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_DMV_GRANULAR }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Verify npm auth
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_DMV_GRANULAR }}
 
       - name: Publish to npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_DMV_GRANULAR }}
+          HUSKY: '0'


### PR DESCRIPTION
## Summary
- Fix `0.48.22` npm publish failure (`E404` on PUT) introduced after the pnpm migration (#241).
- `actions/setup-node` with `registry-url` writes an `.npmrc` that references `${NODE_AUTH_TOKEN}`; the token was only set on the publish step, so npm attempted to publish with empty credentials (npm returns 404 instead of 401).
- Pass `NODE_AUTH_TOKEN` to the setup-node step, add `npm whoami` for clearer auth failures, set `HUSKY=0` in CI, and add `workflow_dispatch` so failed releases can be retried manually.

## Test plan
- [ ] Merge PR
- [ ] Confirm `NPM_DMV_GRANULAR` secret is valid (regenerate on npmjs.com if `npm whoami` still fails)
- [ ] Re-run publish workflow via **Actions → dmv/publish-to-npm → Run workflow** (or re-publish the `v0.48.22` release)
- [ ] Verify `dicom-microscopy-viewer@0.48.22` appears on npm